### PR TITLE
Include headers inside section tags

### DIFF
--- a/lib/transforms/slim.js
+++ b/lib/transforms/slim.js
@@ -62,8 +62,6 @@ function sectionify (doc) {
 
         section = new libxml.Element(doc, 'section')
       }
-
-      continue
     }
 
     node.remove()


### PR DESCRIPTION
Instead of:

```
 <h2>Asdf</h2>
 <section>
      <p>...</p>
 </section>
```

Do:

```
 <section>
      <h2>Asdf</h2>
      <p>...</p>
 </section>
```

I'm thinking about rendering the UI, we need highly structured data, and having an implicit relation between heading and section content by co-location doesn't seem right.

See [this w3c code example on section usage](http://www.w3.org/TR/html5/sections.html#use-div-for-wrappers).
