### PR TITLE
Remove content type from all routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ node server that proxys restbase
 
 ### Api
 
-`/raw/html/[title]`
-`/slim/html/[title]`
+`/raw/[title]`
+`/slim/[title]`
 
 ## Dev
 

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -1,6 +1,6 @@
 var router = new (require('routes'))
 
-router.addRoute('/raw/html/:title', require('./raw.js'))
-router.addRoute('/slim/html/:title', require('./slim.js'))
+router.addRoute('/raw/:title', require('./raw.js'))
+router.addRoute('/slim/:title', require('./slim.js'))
 
 module.exports = router


### PR DESCRIPTION
Per #16, if/when loot needs to do content negotiation, then we'll add content negotiation.
