### PR TITLE
Remove all inline styles

### DIFF
--- a/lib/transforms/common/index.js
+++ b/lib/transforms/common/index.js
@@ -24,6 +24,8 @@ function preprocess (doc) {
 
   removeAllAttributes(doc.find('//*[@data-mw]'), 'data-mw')
 
+  removeAllAttributes(doc.find('//*[@style]'), 'style')
+
   sectionify(doc)
 }
 


### PR DESCRIPTION
The original intention may have been to remove inline styles that had to be styled around for smaller mobile devices, i.e. whitespace and width. However, the rules that remain either define borders or reset counters, which are never used as all style elements and links to stylesheets have already been removed.

Fixes #14.
