### PR TITLE
Convert slim and slim-lead endpoints to JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,25 @@ consumption by lightweight web apps.
 * `/slim/[title]`
 * `/slim/lead/[title]`
 
+### Response
+
+The `/slim/[title]` and `/slim/lead/[title]` endpoints respond with JSON in the following form:
+
+```json
+{
+  sections: [
+    {
+      title: "",
+      content: "<p>This is the lead section</p>"
+    },
+    {
+      title: "First section",
+      content: "<p>This is the first section</p>"
+    }
+  ]
+}
+```
+
 ## Dev
 
 * `npm install` to get the dependencies.

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ The `/slim/[title]` and `/slim/lead/[title]` endpoints respond with JSON in the 
 
 ```json
 {
-  sections: [
+  "sections": [
     {
-      title: "",
-      content: "<p>This is the lead section</p>"
+      "title": "",
+      "content": "<p>This is the lead section</p>"
     },
     {
-      title: "First section",
-      content: "<p>This is the first section</p>"
+      "title": "First section",
+      "content": "<p>This is the first section</p>"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 loot
 ====
 
-node server that proxys restbase
+A simple Node.js service that aggressively transforms RESTBase content for
+consumption by lightweight web apps.
 
 ## Endpoints
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ consumption by lightweight web apps.
 
 ### Api
 
-* `/raw/[title]`
 * `/slim/[title]`
 * `/slim/lead/[title]`
 

--- a/lib/routes/index.js
+++ b/lib/routes/index.js
@@ -1,6 +1,5 @@
 var router = new (require('routes'))
 
-router.addRoute('/raw/:title', require('./raw'))
 router.addRoute('/slim/:title', require('./slim'))
 router.addRoute('/slim/lead/:title', require('./slim-lead'))
 

--- a/lib/routes/raw.js
+++ b/lib/routes/raw.js
@@ -1,1 +1,0 @@
-module.exports = require('./restbase-req-handler')()

--- a/lib/routes/restbase-req-handler.js
+++ b/lib/routes/restbase-req-handler.js
@@ -14,6 +14,8 @@ module.exports = function (transform) {
   return function (req, res, match) {
     var title = match.params.title
 
+    res.setHeader('Content-Type', 'application/json; charset=utf-8')
+
     checkCache(match.route, title, function (err, cachePath) {
       // Cache miss
       if (err) {
@@ -27,7 +29,11 @@ module.exports = function (transform) {
           })
           .catch((e) => {
             res.statusCode = 500
-            res.end(e.message)
+            res.end(JSON.encode({
+              error: {
+                message: e.message
+              }
+            }))
           })
       } else {
         fs.createReadStream(cachePath).pipe(res)

--- a/lib/routes/restbase-req-handler.js
+++ b/lib/routes/restbase-req-handler.js
@@ -3,14 +3,11 @@ var concat = require('concat-stream')
 var getRestbaseHtml = require('../net/restbase')
 var checkCache = require('../cache')
 
-var identity = (x) => x
-
 // Creates a request handler function that will return parsoid html either from
 // the cache or the restbase service applying the specified `transform`.
 //
 // `transform`: Stream -> Stream
 module.exports = function (transform) {
-  transform = transform || identity
   return function (req, res, match) {
     var title = match.params.title
 

--- a/lib/routes/restbase-req-handler.js
+++ b/lib/routes/restbase-req-handler.js
@@ -26,7 +26,7 @@ module.exports = function (transform) {
           })
           .catch((e) => {
             res.statusCode = 500
-            res.end(JSON.encode({
+            res.end(JSON.stringify({
               error: {
                 message: e.message
               }

--- a/lib/transforms/common/index.js
+++ b/lib/transforms/common/index.js
@@ -112,26 +112,30 @@ function prepareSections (sections) {
   var i
   var results = []
   var section
-  var result
   var node
 
   for (i = 0; i < sections.length; ++i) {
     section = sections[i]
-    result = {
-      title: '',
-      content: section.toString()
-    }
-
+    title = ''
     node = section.get('h2')
 
     if (node) {
-      result.title = node.text()
+      title = node.text()
 
       node.remove()
     }
 
-    results.push(result)
+    results.push({
+      title: title,
+      content: innerHTML(section)
+    })
   }
 
   return results
+}
+
+function innerHTML (node) {
+  return node.childNodes()
+    .map((n) => n.toString())
+    .join('\n')
 }

--- a/lib/transforms/common/index.js
+++ b/lib/transforms/common/index.js
@@ -3,7 +3,12 @@ var libxml = require('libxmljs')
 exports.slim = (html) => {
   var doc = libxml.parseHtmlString(html)
 
-  preprocess(doc)
+  preProcess(doc)
+
+  sectionify(doc)
+  imagify(doc)
+
+  postProcess(doc)
 
   return doc.get('body')
 }
@@ -14,17 +19,21 @@ exports.slim = (html) => {
  *
  * `doc`: `libxml.Document`
  */
-function preprocess (doc) {
+function preProcess (doc) {
   removeAll(doc.find('//style'))
   removeAll(doc.find('//link[@rel="stylesheet"]'))
 
   removeAll(doc.find('//comment()'))
+}
 
-  imagify(doc)
-
+/**
+ * Remove all `data-mw` attributes as no further processing that might require
+ * them is taking place.
+ *
+ * `doc`: `libxml.Document`
+ */
+function postProcess (doc) {
   removeAllAttributes(doc.find('//*[@data-mw]'), 'data-mw')
-
-  sectionify(doc)
 }
 
 function removeAll (nodes) {
@@ -51,7 +60,7 @@ function removeAllAttributes (nodes, attribute) {
  * `doc`: `libxml.Document`
  */
 function imagify (doc) {
-  var nodes = doc.find( '//img' );
+  var nodes = doc.find('//img')
   var i
 
   for (i = 0; i < nodes.length; ++i) {
@@ -91,4 +100,38 @@ function sectionify (doc) {
   }
 
   body.addChild(section)
+}
+
+exports.toJson = (body) => {
+  return JSON.stringify({
+    sections: prepareSections(body.childNodes())
+  })
+}
+
+function prepareSections (sections) {
+  var i
+  var results = []
+  var section
+  var result
+  var node
+
+  for (i = 0; i < sections.length; ++i) {
+    section = sections[i]
+    result = {
+      title: '',
+      content: section.toString()
+    }
+
+    node = section.get('h2')
+
+    if (node) {
+      result.title = node.text()
+
+      node.remove()
+    }
+
+    results.push(result)
+  }
+
+  return results
 }

--- a/lib/transforms/slim-lead.js
+++ b/lib/transforms/slim-lead.js
@@ -1,13 +1,26 @@
 var common = require('./common')
 
 module.exports = (html) => {
-  var leadSection = common.slim(html).child(0)
+  var body = common.slim(html)
+  var leadSection = body.child(0)
 
+  removeNonLeadSections(body)
   removeRefLinks(leadSection)
 
-  return leadSection.toString()
+  return common.toJson(body)
+}
+
+function removeNonLeadSections (body) {
+  var nodes = body.childNodes()
+  var i
+
+  for (i = 1; i < nodes.length; ++i) {
+    nodes[i].remove()
+  }
 }
 
 function removeRefLinks (el) {
+  // TODO: Reinstate ref links in the lead section once per-section reference
+  // extraction is working.
   common.removeAll(el.find('//*[@typeof="mw:Extension/ref"]'))
 }

--- a/lib/transforms/slim.js
+++ b/lib/transforms/slim.js
@@ -1,7 +1,3 @@
 var common = require('./common')
 
-module.exports = (html) =>
-  common.slim(html)
-    .childNodes()
-    .map((n) => n.toString())
-    .join('\n')
+module.exports = (html) => common.toJson(common.slim(html))

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "loot",
   "version": "1.0.0",
-  "description": "",
+  "description": "A simple Node.js service that aggressively transforms RESTBase content for consumption by lightweight web apps.",
   "main": "index.js",
   "scripts": {
     "start": "nodemon index.js",


### PR DESCRIPTION
... not HTML5 fragments.

Convert

``` html
<body>
  <section>
    <p>This is the lead section</p>
  </section>
  <section>
    <h2>First section</h2>
    <p>This is the first section</p>
  </section>
</body>
```

to

``` json
{
  "sections": [
    {
      "title": "",
      "content": "<p>This is the lead section</p>"
    },
    {
      "title": "First section",
      "content": "<p>This is the first section</p>"
    }
  ]
}
```

~~Note well that, currently, `section.content` includes the section tag because `libxml.Element#toString` includes it.~~ Fixed in 4ccda0e.
## TODO
- [x] Convert slim and slim-lead endpoints to JSON
  - [x] Return the inner HTML of the section
- [x] Document the responses format in the README for example
