### PR TITLE
Improve image transformation for HTML only mode

### DIFF
--- a/lib/transforms/common/index.js
+++ b/lib/transforms/common/index.js
@@ -69,9 +69,9 @@ function imagify (doc) {
   var i
 
   for (i = 0; i < nodes.length; ++i) {
-    var img = nodes[i]
-    var parent = img.parent()
-    var link = img
+    var img = nodes[i],
+      parent = img.parent(),
+      link = img
     if (parent.name() === 'a') {
       img.name('span')
       link = parent
@@ -82,6 +82,14 @@ function imagify (doc) {
       href: img.attr('src').value()
     })
     img.text(img.attr('resource').value())
+    img.attr({
+      style: [
+        'display: inline-block;',
+        `width: ${img.attr('width').value()}px;`,
+        `height: ${img.attr('height').value()}px;`,
+        'overflow: hidden'
+      ].join('')
+    })
   }
 }
 

--- a/lib/transforms/common/index.js
+++ b/lib/transforms/common/index.js
@@ -55,7 +55,12 @@ function removeAllAttributes (nodes, attribute) {
 }
 
 /**
- * Rewrite all `img` elements as `span` elements.
+ * Rewrite all `img` elements:
+ *
+ * - As `span` elements if their parent is an `a`
+ * - As `a` elements if their parent is not an `a`
+ * - Add the file name as text for the rewritten image
+ * - Set the href of the link to the full image
  *
  * `doc`: `libxml.Document`
  */
@@ -64,7 +69,19 @@ function imagify (doc) {
   var i
 
   for (i = 0; i < nodes.length; ++i) {
-    nodes[i].name('span')
+    var img = nodes[i]
+    var parent = img.parent()
+    var link = img
+    if (parent.name() === 'a') {
+      img.name('span')
+      link = parent
+    } else {
+      img.name('a')
+    }
+    link.attr({
+      href: img.attr('src').value()
+    })
+    img.text(img.attr('resource').value())
   }
 }
 

--- a/lib/transforms/common/index.js
+++ b/lib/transforms/common/index.js
@@ -69,27 +69,31 @@ function imagify (doc) {
   var i
 
   for (i = 0; i < nodes.length; ++i) {
-    var img = nodes[i],
-      parent = img.parent(),
-      link = img
-    if (parent.name() === 'a') {
-      img.name('span')
-      link = parent
-    } else {
-      img.name('a')
+    try {
+      var img = nodes[i],
+        parent = img.parent(),
+        link = img
+      if (parent.name() === 'a') {
+        img.name('span')
+        link = parent
+      } else {
+        img.name('a')
+      }
+      link.attr({
+        href: img.attr('src').value()
+      })
+      img.text((img.attr('resource') || img.attr('src')).value())
+      img.attr({
+        style: [
+          'display: inline-block;',
+          `width: ${img.attr('width').value()}px;`,
+          `height: ${img.attr('height').value()}px;`,
+          'overflow: hidden'
+        ].join('')
+      })
+    } catch (e) {
+      console.log(img.toString(), '\n', e.stack)
     }
-    link.attr({
-      href: img.attr('src').value()
-    })
-    img.text(img.attr('resource').value())
-    img.attr({
-      style: [
-        'display: inline-block;',
-        `width: ${img.attr('width').value()}px;`,
-        `height: ${img.attr('height').value()}px;`,
-        'overflow: hidden'
-      ].join('')
-    })
   }
 }
 


### PR DESCRIPTION
So that you get clickable links to the image in the browser

``` html
<figure or span><img src='hi.jpg' resource='Hi' /></figure or span>
to
<figure or span><a href='hi.jpg'>Hi</a></figure or span>
```

``` html
<a href='./Hi'><img src='hi.jpg' resource='Hi' /></a>
to
<a href='hi.jpg'><span>Hi</span></a>
```

Maintains all the existing attributes for the moment.

Reference: https://www.mediawiki.org/wiki/Parsoid/MediaWiki_DOM_spec#Images

---

Also added width and height so that the html block maintains the image ratio and when we load it in the browser it doesn't trigger layouts.

Add basic styles to make no-images fill their space

So that when they load on the client they don't cause layouts.

I don't like the inline styles at all... but...

See https://i.imgur.com/bTNbWfB.png
