### PR TITLE
Tranform images using a wrapper. Preserve original markup

### DIFF
--- a/lib/transforms/common/index.js
+++ b/lib/transforms/common/index.js
@@ -72,20 +72,23 @@ function imagify (doc) {
 
   for (i = 0; i < nodes.length; ++i) {
     try {
-      var img = nodes[i],
-        parent = img.parent(),
-        link = img
-      if (parent.name() === 'a') {
-        img.name('span')
-        link = parent
-      } else {
-        img.name('a')
-      }
-      link.attr({
-        href: img.attr('src').value()
-      })
-      img.text((img.attr('resource') || img.attr('src')).value())
-      img.attr({
+      var img = nodes[i]
+      var parent = img.parent()
+      // The image wrapper will be a link if the parent is not
+      var wrapperName = parent.name() === 'a' ? 'span' : 'a'
+      // The text of the wrapper is the file name
+      var wrapperText = (img.attr('resource') || img.attr('src')).value()
+      // Add the wrapper to the parent of the image
+      var wrapper = parent.node(wrapperName, wrapperText)
+
+      wrapper.attr({
+        // Set href to link to image for html-only
+        href: img.attr('src').value(),
+        // Set attribute with original markup
+        'data-replace-with': img.toString(),
+        // Set class to make it searchable on the DOM
+        class: 'LootTransformedImage',
+        // Set styles to fix it's size and avoid reflows when lazy loading
         style: [
           'display: inline-block;',
           `width: ${img.attr('width').value()}px;`,
@@ -93,6 +96,9 @@ function imagify (doc) {
           'overflow: hidden'
         ].join('')
       })
+
+      // Get rid of original image in the document
+      img.remove()
     } catch (e) {
       console.log(img.toString(), '\n', e.stack)
     }


### PR DESCRIPTION
In order to lazy load images on the client, we need to preserve the original
markup on a wrapper element, instead of rewriting the image node itself.

``` html
<figure or span><img src='hi.jpg' resource='Hi' /></figure or span>
to
<figure or span>
   <a class='LootTransformedImage' href='hi.jpg'
      style='...' data-replace-with='<img src=\'hi.jpg\' resource=\'Hi\' />'>
      Hi
   </a>
</figure or span>
```

``` html
<a href='./Hi'><img src='hi.jpg' resource='Hi' /></a>
to
<a href='hi.jpg'>
   <span style='...' data-replace-with='<img src=\'hi.jpg\' resource=\'Hi\' />'>
      Hi
   </span>
</a>
```
