### PR TITLE
Redirects should be automatically handled

### DIFF
--- a/lib/routes/restbase-req-handler.js
+++ b/lib/routes/restbase-req-handler.js
@@ -3,6 +3,7 @@ var concat = require('concat-stream')
 var getRestbaseHtml = require('../net/restbase')
 var checkCache = require('../cache')
 var handleError = require('./common').handleError
+var libxml = require('libxmljs')
 
 // Creates a request handler function that will return parsoid html either from
 // the cache or the restbase service applying the specified `transform`.
@@ -17,14 +18,26 @@ module.exports = function (transform) {
     checkCache(match.route, title, function (err, cachePath) {
       // Cache miss
       if (err) {
-        getRestbaseHtml(title)
-          .then((restRes) => {
-            restRes.pipe(concat((contents) => {
-              var transformed = transform(contents)
+        var handler = (restRes) => {
+          restRes.pipe(concat((contents) => {
+            var doc = libxml.parseHtmlString(contents)
+            // Handle redirect
+            var redirect = doc.find('//link[@rel="mw:PageProp\/redirect"]')[0]
+            if(redirect){
+              // Make subsequent request
+              getRestbaseHtml(redirect.attr( 'href' ).value().slice(2))
+                .then(handler)
+                .catch((e) => handleError(res, e))
+            } else {
+              var transformed = transform(doc)
               res.end(transformed)
               fs.writeFile(cachePath, transformed)
-            }))
-          })
+            }
+          }))
+        }
+
+        getRestbaseHtml(title)
+          .then(handler)
           .catch((e) => handleError(res, e))
       } else {
         fs.createReadStream(cachePath).pipe(res)

--- a/lib/transforms/common/index.js
+++ b/lib/transforms/common/index.js
@@ -1,15 +1,12 @@
 var libxml = require('libxmljs')
 
-exports.slim = (html) => {
-  var doc = libxml.parseHtmlString(html)
-
+exports.slim = (doc) => {
   preProcess(doc)
 
   sectionify(doc)
   imagify(doc)
 
   postProcess(doc)
-
   return doc.get('body')
 }
 

--- a/lib/transforms/slim-lead.js
+++ b/lib/transforms/slim-lead.js
@@ -1,7 +1,7 @@
 var common = require('./common')
 
-module.exports = (html) => {
-  var body = common.slim(html)
+module.exports = (doc) => {
+  var body = common.slim(doc)
   var leadSection = body.child(0)
 
   removeNonLeadSections(body)

--- a/lib/transforms/slim.js
+++ b/lib/transforms/slim.js
@@ -1,3 +1,3 @@
 var common = require('./common')
 
-module.exports = (html) => common.toJson(common.slim(html))
+module.exports = (doc) => common.toJson(common.slim(doc))


### PR DESCRIPTION
When encountering a redirect link tag we should
make a subsequent request and return the content.
If we ever want to allow access to this we can do so
with some kind of flag.

Changes:
- Routes now take a libxml doc

Fixes:
- https://github.com/joakin/loot-ui/issues/28
