### PR TITLE
Improve on redirect handling

### DIFF
--- a/lib/routes/restbase-req-handler.js
+++ b/lib/routes/restbase-req-handler.js
@@ -24,10 +24,9 @@ module.exports = function (transform) {
             // Handle redirect
             var redirect = doc.find('//link[@rel="mw:PageProp/redirect"]')[0]
             if (redirect) {
-              // Make subsequent request
-              getRestbaseHtml(redirect.attr('href').value().slice(2))
-                .then(handler)
-                .catch((e) => handleError(res, e))
+              var redirectTitle = redirect.attr('href').value().slice(2)
+              res.writeHead(301, { Location: redirectTitle })
+              res.end()
             } else {
               var transformed = transform(doc)
               res.end(transformed)

--- a/lib/routes/restbase-req-handler.js
+++ b/lib/routes/restbase-req-handler.js
@@ -22,7 +22,7 @@ module.exports = function (transform) {
           restRes.pipe(concat((contents) => {
             var doc = libxml.parseHtmlString(contents)
             // Handle redirect
-            var redirect = doc.find('//link[@rel="mw:PageProp\/redirect"]')[0]
+            var redirect = doc.find('//link[@rel="mw:PageProp/redirect"]')[0]
             if (redirect) {
               // Make subsequent request
               getRestbaseHtml(redirect.attr('href').value().slice(2))

--- a/lib/routes/restbase-req-handler.js
+++ b/lib/routes/restbase-req-handler.js
@@ -23,9 +23,9 @@ module.exports = function (transform) {
             var doc = libxml.parseHtmlString(contents)
             // Handle redirect
             var redirect = doc.find('//link[@rel="mw:PageProp\/redirect"]')[0]
-            if(redirect){
+            if (redirect) {
               // Make subsequent request
-              getRestbaseHtml(redirect.attr( 'href' ).value().slice(2))
+              getRestbaseHtml(redirect.attr('href').value().slice(2))
                 .then(handler)
                 .catch((e) => handleError(res, e))
             } else {

--- a/lib/routes/restbase-req-handler.js
+++ b/lib/routes/restbase-req-handler.js
@@ -3,6 +3,7 @@ var concat = require('concat-stream')
 var getRestbaseHtml = require('../net/restbase')
 var checkCache = require('../cache')
 var handleError = require('./common').handleError
+var libxml = require('libxmljs')
 
 // Creates a request handler function that will return parsoid html either from
 // the cache or the restbase service applying the specified `transform`.
@@ -17,14 +18,26 @@ module.exports = function (transform) {
     checkCache(match.route, title, function (err, cachePath) {
       // Cache miss
       if (err) {
-        getRestbaseHtml(title)
-          .then((restRes) => {
-            restRes.pipe(concat((contents) => {
-              var transformed = transform(contents)
+        var handler = (restRes) => {
+          restRes.pipe(concat((contents) => {
+            var doc = libxml.parseHtmlString(contents)
+            // Handle redirect
+            var redirect = doc.find('//link[@rel="mw:PageProp\/redirect"]')[0]
+            if(redirect){
+              // Make subsequent request
+              getRestbaseHtml(redirect.attr( 'href' ).value().slice(2))
+                .then(handler)
+                .catch((e) => handleError(res, e))
+            } else {
+              var transformed = transform(doc)
               res.end(transformed)
               fs.writeFile(cachePath, transformed)
-            }))
-          })
+            }
+          }))
+        }
+
+        getRestbaseHtml(title)
+          .then(handler)
           .catch((e) => handleError(res, e))
       } else {
         fs.createReadStream(cachePath).pipe(res)

--- a/lib/transforms/common/index.js
+++ b/lib/transforms/common/index.js
@@ -1,15 +1,12 @@
 var libxml = require('libxmljs')
 
-exports.slim = (html) => {
-  var doc = libxml.parseHtmlString(html)
-
+exports.slim = (doc) => {
   preProcess(doc)
 
   sectionify(doc)
   imagify(doc)
 
   postProcess(doc)
-
   return doc.get('body')
 }
 

--- a/lib/transforms/slim-lead.js
+++ b/lib/transforms/slim-lead.js
@@ -1,7 +1,7 @@
 var common = require('./common')
 
-module.exports = (html) => {
-  var body = common.slim(html)
+module.exports = (doc) => {
+  var body = common.slim(doc)
   var leadSection = body.child(0)
 
   removeNonLeadSections(body)

--- a/lib/transforms/slim.js
+++ b/lib/transforms/slim.js
@@ -1,3 +1,3 @@
 var common = require('./common')
 
-module.exports = (html) => common.toJson(common.slim(html))
+module.exports = (doc) => common.toJson(common.slim(doc))


### PR DESCRIPTION
Make the API properly conform rest & http by returning 301s when encountering parsoids link[redirect] tag instead of squashing the content for a title that doesn't actually have it (this would cause havoc later when trying to edit, etc).
