### PR TITLE
Surface last edit information for last modified bar rendering

### DIFF
--- a/lib/transforms/common/index.js
+++ b/lib/transforms/common/index.js
@@ -7,7 +7,7 @@ exports.slim = (doc) => {
   imagify(doc)
 
   postProcess(doc)
-  return doc.get('body')
+  return doc
 }
 
 /**
@@ -138,9 +138,18 @@ function sectionify (doc) {
   body.addChild(section)
 }
 
-exports.toJson = (body) => {
+exports.toJson = (doc) => {
+  var modifier = doc.find('//meta[@property="dc:title"]')[0]
+  var id = modifier.attr('about').value().split('/')[1]
   return JSON.stringify({
-    sections: prepareSections(body.childNodes())
+    lastmodified: {
+      by: {
+        isAnonymous: id === '0',
+        name: modifier.attr('content').value()
+      },
+      at: doc.find('//meta[@property="dc:modified"]')[0].attr('content').value()
+    },
+    sections: prepareSections(doc.get('body').childNodes())
   })
 }
 

--- a/lib/transforms/slim-lead.js
+++ b/lib/transforms/slim-lead.js
@@ -1,13 +1,14 @@
 var common = require('./common')
 
 module.exports = (doc) => {
-  var body = common.slim(doc)
+  var slimDoc = common.slim(doc)
+  var body = slimDoc.get('body')
   var leadSection = body.child(0)
 
   removeNonLeadSections(body)
   removeRefLinks(leadSection)
 
-  return common.toJson(body)
+  return common.toJson(slimDoc)
 }
 
 function removeNonLeadSections (body) {


### PR DESCRIPTION
Changes:
- Now the transforms return the doc rather than the body element so
  further processing can be done in toJSON

Fixes: #40
