### PR TITLE
Fix exceptions when parsing images without width/height attrs

### DIFF
--- a/lib/transforms/common/index.js
+++ b/lib/transforms/common/index.js
@@ -135,8 +135,10 @@ function imagify (doc) {
         // Set styles to fix it's size and avoid reflows when lazy loading
         style: [
           'display: inline-block;',
-          `width: ${img.attr('width').value()}px;`,
-          `height: ${img.attr('height').value()}px;`,
+          img.attr('width')
+            ? `width: ${img.attr('width').value()}px;` : '',
+          img.attr('height')
+            ? `height: ${img.attr('height').value()}px;` : '',
           'overflow: hidden'
         ].join('')
       })


### PR DESCRIPTION
Example exception:

```
<img class="mwe-math-fallback-image-inline tex" alt="S"
src="//upload.wikimedia.org/math/5/d/b/5dbc98dcc983a70728bd082d1a47546e.png"
typeof="mw:Extension/math"
data-mw='{"name":"math","attrs":{},"body":{"extsrc":"S"}}' about="#mwt62"
id="mwbA">
 TypeError: Cannot read property 'value' of null
     at imagify
     (/Users/jhernandez/dev/loot/lib/transforms/common/index.js:138:38)
```

Test with http://localhost:7002/wiki/Euclidean%20distance for example.
