### PR TITLE
Make imagify maintain the original node

### DIFF
--- a/lib/transforms/common/index.js
+++ b/lib/transforms/common/index.js
@@ -117,22 +117,14 @@ function imagify (doc) {
   for (i = 0; i < nodes.length; ++i) {
     try {
       var img = nodes[i]
-      var parent = img.parent()
-      // The image wrapper will be a link if the parent is not
-      var wrapperName = parent.name() === 'a' ? 'span' : 'a'
-      // The text of the wrapper is the file name
-      var wrapperText = (img.attr('resource') || img.attr('src')).value()
-      // Add the wrapper to the parent of the image
-      var wrapper = parent.node(wrapperName, wrapperText)
-
-      wrapper.attr({
-        // Set href to link to image for html-only
-        href: img.attr('src').value(),
-        // Set attribute with original markup
-        'data-replace-with': img.toString(),
-        // Set class to make it searchable on the DOM
-        class: 'LootTransformedImage',
-        // Set styles to fix it's size and avoid reflows when lazy loading
+      img.attr({
+        src: '',
+        'data-src': img.attr('src').value(),
+        srcset: '',
+        'data-srcset': img.attr('srcset').value(),
+        title: img.attr('title')
+          ? img.attr('title').value()
+          : (img.attr('resource') || img.attr('src')).value(),
         style: [
           'display: inline-block;',
           img.attr('width')
@@ -142,9 +134,6 @@ function imagify (doc) {
           'overflow: hidden'
         ].join('')
       })
-
-      // Get rid of original image in the document
-      img.remove()
     } catch (e) {
       console.log(img.toString(), '\n', e.stack)
     }


### PR DESCRIPTION
Instead of creating a new one and putting the old node's html in an attribute.

Now it just removes the src and srcset of the images and moves them to the
data-src and data-srcset attributes for the client to replace back. It also
sets a title so that it shows when the image is not loaded, and some inline
styles to preserve layout when the image is not loaded.

**Depends on https://github.com/joakin/loot/pull/52**

Will send PR for loot-ui now.
